### PR TITLE
修复进行OTFAD加密时出现的各种问题 Fix the problems when proceeding OTFAD encryption

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -63,7 +63,7 @@
 
 > Note4: 必须使用Python2 x86版本去打包NXP-MCUBootUtility，因为NXP-MCUBootUtility使用了pywinusb库，该库在Python2 x64版本下无法用PyInstaller打包，pywinusb作者没有计划修复该问题。  
 
-> Note5: 改變芯片工作頻率的代碼不能被加密，如果你的代碼有使用到 BOARD_BootClockRUN 或 其他改變芯片工作頻率的函數，你應該把那些代碼放到非加密的區域。
+> Note5: 改变芯片工作频率的代码不能被加密，如果你的代码有使用到 BOARD_BootClockRUN 或 其他改变芯片工作频率的函数，你应该把那些代码放到非加密的区域。
 
 #### 1.3 安装
 　　NXP-MCUBootUtility是一个是纯绿色免安装的工具，下载了源代码包之后，直接双击\NXP-MCUBootUtility\bin\NXP-MCUBootUtility.exe即可使用。使用NXP-MCUBootUtility没有任何软件依赖，不需要额外安装任何软件。  

--- a/README-zh.md
+++ b/README-zh.md
@@ -63,6 +63,8 @@
 
 > Note4: 必须使用Python2 x86版本去打包NXP-MCUBootUtility，因为NXP-MCUBootUtility使用了pywinusb库，该库在Python2 x64版本下无法用PyInstaller打包，pywinusb作者没有计划修复该问题。  
 
+> Note5: 改變芯片工作頻率的代碼不能被加密，如果你的代碼有使用到 BOARD_BootClockRUN 或 其他改變芯片工作頻率的函數，你應該把那些代碼放到非加密的區域。
+
 #### 1.3 安装
 　　NXP-MCUBootUtility是一个是纯绿色免安装的工具，下载了源代码包之后，直接双击\NXP-MCUBootUtility\bin\NXP-MCUBootUtility.exe即可使用。使用NXP-MCUBootUtility没有任何软件依赖，不需要额外安装任何软件。  
 　　在NXP-MCUBootUtility.exe图形界面显示之前，会首先弹出一个控制台窗口，该控制台会伴随着NXP-MCUBootUtility.exe图形界面一起工作，很多图形界面的操作都会在控制台窗口看到对应的底层命令执行，保留控制台主要是为了便于定位NXP-MCUBootUtility.exe的问题，目前NXP-MCUBootUtility尚处于早期阶段，等后期软件成熟会考虑移除控制台。  

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ English | [中文](./README-zh.md)
 
 > Note4: You must use Python2 x86 version, because NXP-MCUBootUtility uses the pywinusb library, which cannot be packaged by PyInstaller in Python2 x64 version. The pywinusb author has no plan to fix the problem.  
 
+> Note5: You cannot make any frequency adjustments in the encrypted code area, if your code includes calling of BOARD_BootClockRUN or any other frequency adjustment function, you should allocate those functions and the function called inside into non encrypted code area.  
+
 #### 1.3 Installation
 　　NXP-MCUBootUtility is a pure green free installation tool. After downloading the source code package, double-click "\NXP-MCUBootUtility\bin\NXP-MCUBootUtility.exe" to use it. No additional software is required.  
 　　Before the NXP-MCUBootUtility.exe graphical interface is displayed, a console window will pop up first. The console will work along with the NXP-MCUBootUtility.exe graphical interface. The console is mainly for the purpose of showing error information of NXP-MCUBootUtility.exe. At present, NXP-MCUBootUtility is still in development stage, and the console will be removed when the NXP-MCUBootUtility is fully validated.

--- a/src/gen/RTyyyy_gencore.py
+++ b/src/gen/RTyyyy_gencore.py
@@ -1166,6 +1166,8 @@ class secBootRTyyyyGen(RTyyyy_uicore.secBootRTyyyyUi):
             bdContent += "    myBinFile = extern (0);\n"
             if self.secureBootType == RTyyyy_uidef.kSecureBootType_HabCrypto:
                 bdContent += "    dekFile = extern (1);\n"
+            elif self.secureBootType == RTyyyy_uidef.kSecureBootType_OtfadCrypto:
+                bdContent += "    otfadKeyblobFile = extern (1);\n"
         else:
             pass
         bdContent += "}\n"

--- a/src/run/RTyyyy_runcore.py
+++ b/src/run/RTyyyy_runcore.py
@@ -1264,7 +1264,7 @@ class secBootRTyyyyRun(RTyyyy_gencore.secBootRTyyyyGen):
             fileObj.write(imageData)
             fileObj.close()
 
-    def _programFlexspiNorOtfadKeyBlob( self ):
+    def _programFlexspiNorOtfadKeyBlob( self, imageLoadAddr ):
         otfadKeyblobLoadAddr = self.bootDeviceMemBase + RTyyyy_memdef.kMemBlockOffset_HwCryptoKeyBlob
         status = boot.status.kStatus_Success
         if self.isSbFileEnabledToGen:
@@ -1342,7 +1342,7 @@ class secBootRTyyyyRun(RTyyyy_gencore.secBootRTyyyyGen):
                     self.printLog(cmdStr)
                 if self.secureBootType == RTyyyy_uidef.kSecureBootType_OtfadCrypto:
                     self._extractOtfadKeyblobFromDestEncAppFile()
-                    if not self._programFlexspiNorOtfadKeyBlob():
+                    if not self._programFlexspiNorOtfadKeyBlob(self.bootDeviceMemBase):
                         self.isFlexspiNorErasedForImage = False
                         self.isFdcbFromSrcApp = False
                         return False

--- a/src/run/RTyyyy_runcore.py
+++ b/src/run/RTyyyy_runcore.py
@@ -1111,6 +1111,8 @@ class secBootRTyyyyRun(RTyyyy_gencore.secBootRTyyyyGen):
         lock = self.RTyyyy_readMcuDeviceFuseByBlhost(self.tgt.efusemapIndexDict['kEfuseIndex_LOCK'], '', False)
         if lock != None:
             lock = ((RTyyyy_fusedef.kEfuseMask_WLockSwGp2 | RTyyyy_fusedef.kEfuseMask_RLockSwGp2) | lock) ^ lock
+            if self.isSbFileEnabledToGen:
+                lock = (RTyyyy_fusedef.kEfuseMask_WLockSwGp2 | RTyyyy_fusedef.kEfuseMask_RLockSwGp2)
             burnResult = self.RTyyyy_burnMcuDeviceFuseByBlhost(self.tgt.efusemapIndexDict['kEfuseIndex_LOCK'], lock)
             if not burnResult:
                 #self.popupMsgBox(uilang.kMsgLanguageContentDict['burnFuseError_failToBurnSwgp2Lock'][self.languageIndex])
@@ -1124,6 +1126,8 @@ class secBootRTyyyyRun(RTyyyy_gencore.secBootRTyyyyGen):
         lock = self.RTyyyy_readMcuDeviceFuseByBlhost(self.tgt.efusemapIndexDict['kEfuseIndex_LOCK'], '', False)
         if lock != None:
             lock = ((RTyyyy_fusedef.kEfuseMask_WLockGp4 | RTyyyy_fusedef.kEfuseMask_RLockGp4) | lock) ^ lock
+            if self.isSbFileEnabledToGen:
+                lock = (RTyyyy_fusedef.kEfuseMask_WLockGp4 | RTyyyy_fusedef.kEfuseMask_RLockGp4)
             burnResult = self.RTyyyy_burnMcuDeviceFuseByBlhost(self.tgt.efusemapIndexDict['kEfuseIndex_LOCK'], lock)
             if not burnResult:
                 #self.popupMsgBox(uilang.kMsgLanguageContentDict['burnFuseError_failToBurnGp4Lock'][self.languageIndex])
@@ -1172,8 +1176,8 @@ class secBootRTyyyyRun(RTyyyy_gencore.secBootRTyyyyGen):
         keyWords = RTyyyy_gendef.kSecKeyLengthInBits_DEK / 32
         if needToBurnSwGp2:
             isReady, isBlank = self._isDeviceFuseSwGp2RegionReadyForBurn(swgp2DekFilename)
-            if isReady:
-                if isBlank:
+            if isReady or self.isSbFileEnabledToGen:
+                if isBlank or self.isSbFileEnabledToGen:
                     for i in range(keyWords):
                         val32 = self.getVal32FromBinFile(swgp2DekFilename, (i * 4))
                         burnResult = self.RTyyyy_burnMcuDeviceFuseByBlhost(self.tgt.efusemapIndexDict['kEfuseIndex_SW_GP2_0'] + i, val32)
@@ -1188,8 +1192,8 @@ class secBootRTyyyyRun(RTyyyy_gencore.secBootRTyyyyGen):
             pass
         if needToBurnGp4:
             isReady, isBlank = self._isDeviceFuseGp4RegionReadyForBurn(gp4DekFilename)
-            if isReady:
-                if isBlank:
+            if isReady or self.isSbFileEnabledToGen:
+                if isBlank or self.isSbFileEnabledToGen:
                     for i in range(keyWords):
                         val32 = self.getVal32FromBinFile(gp4DekFilename, (i * 4))
                         burnResult = self.RTyyyy_burnMcuDeviceFuseByBlhost(self.tgt.efusemapIndexDict['kEfuseIndex_GP4_0'] + i, val32)
@@ -1204,8 +1208,8 @@ class secBootRTyyyyRun(RTyyyy_gencore.secBootRTyyyyGen):
             pass
         if needToBurnUserKey5:
             isReady, isBlank = self._isDeviceFuseUserKey5RegionReadyForBurn(userkey5DekFilename)
-            if isReady:
-                if isBlank:
+            if isReady or self.isSbFileEnabledToGen:
+                if isBlank or self.isSbFileEnabledToGen:
                     for i in range(keyWords):
                         val32 = self.getVal32FromBinFile(userkey5DekFilename, (i * 4))
                         burnResult = self.RTyyyy_burnMcuDeviceFuseByBlhost(self.tgt.efusemapIndexDict['kEfuseIndex_USER_KEY5_0'] + i, val32)

--- a/src/run/RTyyyy_runcore.py
+++ b/src/run/RTyyyy_runcore.py
@@ -1563,14 +1563,16 @@ class secBootRTyyyyRun(RTyyyy_gencore.secBootRTyyyyGen):
             destHwCryptoKeySel = 0
             if setHwCryptoKey0Sel != None:
                 destHwCryptoKeySel = getHwCryptoKeySel | (setHwCryptoKey0Sel << self.tgt.efusemapDefnDict['kEfuseShift_HwCryptoKey0Sel'])
-                if ((getHwCryptoKeySel & self.tgt.efusemapDefnDict['kEfuseMask_HwCryptoKey0Sel']) >> self.tgt.efusemapDefnDict['kEfuseShift_HwCryptoKey0Sel']) != setHwCryptoKey0Sel:
+                currHwCryptoKey0Sel = ((getHwCryptoKeySel & self.tgt.efusemapDefnDict['kEfuseMask_HwCryptoKey0Sel']) >> self.tgt.efusemapDefnDict['kEfuseShift_HwCryptoKey0Sel'])
+                if currHwCryptoKey0Sel and currHwCryptoKey0Sel != setHwCryptoKey0Sel:
                     self.popupMsgBox(uilang.kMsgLanguageContentDict['burnFuseError_hwCryptoKey0SelHasBeenBurned'][self.languageIndex])
                     return False
             else:
                 destHwCryptoKeySel = getHwCryptoKeySel
             if setHwCryptoKey1Sel != None:
                 destHwCryptoKeySel = destHwCryptoKeySel | (setHwCryptoKey1Sel << self.tgt.efusemapDefnDict['kEfuseShift_HwCryptoKey1Sel'])
-                if ((getHwCryptoKeySel & self.tgt.efusemapDefnDict['kEfuseMask_HwCryptoKey1Sel']) >> self.tgt.efusemapDefnDict['kEfuseShift_HwCryptoKey1Sel']) != setHwCryptoKey1Sel:
+                currHwCryptoKey1Sel = ((getHwCryptoKeySel & self.tgt.efusemapDefnDict['kEfuseMask_HwCryptoKey1Sel']) >> self.tgt.efusemapDefnDict['kEfuseShift_HwCryptoKey1Sel'])
+                if currHwCryptoKey1Sel and currHwCryptoKey1Sel != setHwCryptoKey1Sel:
                     self.popupMsgBox(uilang.kMsgLanguageContentDict['burnFuseError_hwCryptoKey1SelHasBeenBurned'][self.languageIndex])
                     return False
             destHwCryptoKeySel = destHwCryptoKeySel ^ getHwCryptoKeySel


### PR DESCRIPTION
这个PR 修复了四个问题
1. 修复了进行OTFAD加密的时候会显示 global variable “imageLoadAddr" not defined 的问题
2. 修复了生成OTFAD sb文件后，elftosb 软件会投诉无效的">"字符的问题
3. 修复了软件在芯片对应的efuse没被烧录的情况下提示"Fuse BOOT_CFG1[5:4] XX_KEY0_SEL位已经被烧录过，它只可被烧写一次！"或"Fuse BOOT_CFG1[5: 4] XX_KEY1_SEL位已经被烧录过，它只可被烧写一次！"
4. 修复了软件在芯片对应的efuse已经烧录了的情况下生成的sb文件缺失正确的efuse操作
5. 在README中添加了改变芯片频率的代码不能放到加密区域的提醒

This PR fixes four problems
1. Fix the problem of displaying global variable "imageLoadAddr" not defined and failing to complete follow up action.
2. Fix the problem of the generated OTFAD sb file will be complained by the elftosb software that there is an invalid ">" character.
3. Fix the software stopped the efuse action and warned "Fuse BOOT_CFG1[5:4] XX_KEY0_SEL has been burned, it is program-once!" or "Fuse BOOT_CFG1[5:4] XX_KEY1_SEL has been burned, it is program-once !" when the chip's efuse is actually not burned.
4. Fix the software failed to generate sb file with correct efuse operation when the corresponding chip's efuse bit is already burned.
5. In README added a note about frequency adjustment code cannot be allocated in the encrypted region.